### PR TITLE
added Increment button using React.Fragment

### DIFF
--- a/src/components/counter.jsx
+++ b/src/components/counter.jsx
@@ -1,9 +1,20 @@
-import React, { Component } from 'react';
+import React, { Component } from "react";
 
 class Counter extends Component {
-    render() { 
-        return <h1>Hello World</h1>;    //this is a JSX expression, NOT returning a string
-    }
+  render() {
+    return (
+      //div is the container for the react application (but we don't want multiple divs)
+      //so use React.fragment
+      <React.Fragment>
+        <h1>Hello World</h1>
+        <button>Increment</button>
+      </React.Fragment>
+      /* this is a JSX expression, NOT returning a string
+      JSX unable to render 2 elements h1 and button together
+      so must wrap in a div element
+      */
+    );
+  }
 }
- 
+
 export default Counter;


### PR DESCRIPTION
Initially in the counter.jsx file, we used <div></div> to wrap our two (h1 and button) elements since JSX's babel doesn't know how to compile the expression in that way without the div container. At deployment and inspection, we see there are two <div>s present, but we don't want more than one since one <div> container isn't really doing anything. Instead, we used <React.Fragment> to wrap the two elements and now there are no longer two <div>s.