### PR TITLE
Binding event handlers

### DIFF
--- a/src/components/counter.jsx
+++ b/src/components/counter.jsx
@@ -21,14 +21,14 @@ class Counter extends Component {
     );
   }
 
-  constructor() {
-    super();
-    this.handleIncrement = this.handleIncrement.bind(this);
-  }
+  //constructor() {
+  //  super();
+  //  this.handleIncrement = this.handleIncrement.bind(this);
+  //}
 
-  handleIncrement() {
+  handleIncrement = () => {
     console.log("Increment Clicked", this);
-  }
+  };
 
   render() {
     return (

--- a/src/components/counter.jsx
+++ b/src/components/counter.jsx
@@ -21,8 +21,13 @@ class Counter extends Component {
     );
   }
 
+  constructor() {
+    super();
+    this.handleIncrement = this.handleIncrement.bind(this);
+  }
+
   handleIncrement() {
-    console.log("Increment Clicked");
+    console.log("Increment Clicked", this);
   }
 
   render() {


### PR DESCRIPTION
There are two ways to bind two event handlers. The first requires creating a constructor but can become cumbersome as you must create a constructor for every event. The second utilizes an arrow and is much simpler. However, the use of arrows may not work in future version of JSX/React.